### PR TITLE
Fix Japanese language code

### DIFF
--- a/SimpleDnsCrypt/Tools/LocalizationEx.cs
+++ b/SimpleDnsCrypt/Tools/LocalizationEx.cs
@@ -41,7 +41,7 @@ namespace SimpleDnsCrypt.Tools
 				new Language {Name = "German", ShortCode = "de", CultureCode = "de-DE"},
 				new Language {Name = "Indonesian", ShortCode = "id", CultureCode = "id-ID"},
 				new Language {Name = "Italian", ShortCode = "it", CultureCode = "it-IT"},
-				new Language {Name = "Japanese", ShortCode = "ja", CultureCode = "ja-JA"},
+				new Language {Name = "Japanese", ShortCode = "ja", CultureCode = "ja-JP"},
 				new Language {Name = "Norwegian", ShortCode = "no", CultureCode = "no-NO"},
 				new Language {Name = "Persian", ShortCode = "fa", CultureCode = "fa-FA"},
 				new Language {Name = "Russian", ShortCode = "ru", CultureCode = "ru-RU"},


### PR DESCRIPTION
Frequently used Japanese code is `ja-JP`.

https://msdn.microsoft.com/en-us/library/cc233965.aspx

Thank you,