### PR TITLE
Updated URLs to primary resolvers csv and minisign

### DIFF
--- a/SimpleDnsCrypt/Config/Global.cs
+++ b/SimpleDnsCrypt/Config/Global.cs
@@ -31,19 +31,20 @@
 		///     URL to the dnscrypt-resolvers.csv (hosted on github).
 		/// </summary>
 		public const string ResolverUrl =
-			"https://raw.githubusercontent.com/jedisct1/dnscrypt-proxy/master/dnscrypt-resolvers.csv";
+			"https://raw.githubusercontent.com/jedisct1/dnscrypt-resolvers/master/v1/dnscrypt-resolvers.csv";
+
 
 		/// <summary>
 		///     Backup URL to the dnscrypt-resolvers.csv.
 		/// </summary>
 		public const string ResolverBackupUrl =
 			"https://download.dnscrypt.org/dnscrypt-proxy/dnscrypt-resolvers.csv";
-		
+
 		/// <summary>
 		///     URL to the minisign signature, to verify the downloaded dnscrypt-resolvers.csv (hosted on github).
 		/// </summary>
 		public const string SignatureUrl =
-			"https://raw.githubusercontent.com/jedisct1/dnscrypt-proxy/master/dnscrypt-resolvers.csv.minisig";
+			"https://raw.githubusercontent.com/jedisct1/dnscrypt-resolvers/master/v1/dnscrypt-resolvers.csv.minisig";
 
 		/// <summary>
 		///     URL to the minisign signature, to verify the downloaded dnscrypt-resolvers.csv.
@@ -182,10 +183,10 @@
 		public const string UserConfigurationFile = "config.yaml";
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public const string InsecureResolversFile = "insecure_resolvers.yaml";
-		
+
 		/// <summary>
 		///     List of interfaces, marked as hidden.
 		/// </summary>
@@ -234,22 +235,22 @@
 		public static readonly string[] SupportedLanguages = {"bg", "de", "da", "en", "es", "fr", "fa", "id", "it", "ja", "nl", "no", "ru", "sv", "tr", "zh", "zh-hant"};
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public const string DomainBlacklistConfigFile = "domains-blacklist.yaml";
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public const string DomainBlacklistFile = "domains-blacklist.txt";
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public const string AddressBlacklistConfigFile = "addresses-blacklist.yaml";
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public const string AddressBlacklistFile = "addresses-blacklist.txt";
 


### PR DESCRIPTION
The URLs for the github hosted `dnscrypt-resolvers.csv` and `dnscrypt-resolvers.csv.minisig` have changed.

I've updated the same to reflect the new locations of those files.