### PR TITLE
Enhancements: Clear blacklist button, disable tray mode option & start in tray option

### DIFF
--- a/SimpleDnsCrypt/App.config
+++ b/SimpleDnsCrypt/App.config
@@ -68,10 +68,10 @@
             <setting name="UpgradeRequired" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="TrayMode" serializeAs="String">
-                <value>True</value>
-            </setting>
             <setting name="AutoUpdateSilent" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="StartInTray" serializeAs="String">
                 <value>False</value>
             </setting>
         </SimpleDnsCrypt.Properties.Settings>

--- a/SimpleDnsCrypt/App.config
+++ b/SimpleDnsCrypt/App.config
@@ -74,6 +74,9 @@
             <setting name="StartInTray" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="TrayMode" serializeAs="String">
+                <value>True</value>
+            </setting>
         </SimpleDnsCrypt.Properties.Settings>
     </userSettings>
 </configuration>

--- a/SimpleDnsCrypt/Properties/Settings.Designer.cs
+++ b/SimpleDnsCrypt/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SimpleDnsCrypt.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -193,18 +193,6 @@ namespace SimpleDnsCrypt.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool TrayMode {
-            get {
-                return ((bool)(this["TrayMode"]));
-            }
-            set {
-                this["TrayMode"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool AutoUpdateSilent {
             get {
@@ -212,6 +200,18 @@ namespace SimpleDnsCrypt.Properties {
             }
             set {
                 this["AutoUpdateSilent"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool StartInTray {
+            get {
+                return ((bool)(this["StartInTray"]));
+            }
+            set {
+                this["StartInTray"] = value;
             }
         }
     }

--- a/SimpleDnsCrypt/Properties/Settings.Designer.cs
+++ b/SimpleDnsCrypt/Properties/Settings.Designer.cs
@@ -214,5 +214,17 @@ namespace SimpleDnsCrypt.Properties {
                 this["StartInTray"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool TrayMode {
+            get {
+                return ((bool)(this["TrayMode"]));
+            }
+            set {
+                this["TrayMode"] = value;
+            }
+        }
     }
 }

--- a/SimpleDnsCrypt/Properties/Settings.settings
+++ b/SimpleDnsCrypt/Properties/Settings.settings
@@ -44,10 +44,10 @@
     <Setting Name="UpgradeRequired" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="TrayMode" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
-    </Setting>
     <Setting Name="AutoUpdateSilent" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="StartInTray" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>

--- a/SimpleDnsCrypt/Properties/Settings.settings
+++ b/SimpleDnsCrypt/Properties/Settings.settings
@@ -50,5 +50,8 @@
     <Setting Name="StartInTray" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="TrayMode" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SimpleDnsCrypt/Resources/Translation.en.resx
+++ b/SimpleDnsCrypt/Resources/Translation.en.resx
@@ -142,7 +142,7 @@
     <value>Using IPv6 Server</value>
   </data>
   <data name="default_settings_configuration_ipv6_tooltip" xml:space="preserve">
-    <value>Use servers reachable over IPv6 (do not enable if you don&apos;t have IPv6 connectivity)</value>
+    <value>Use servers reachable over IPv6 (do not enable if you don't have IPv6 connectivity)</value>
   </data>
   <data name="default_settings_configuration_dnssec" xml:space="preserve">
     <value>Only servers with DNSSEC support</value>
@@ -296,19 +296,19 @@
     <value>Settings</value>
   </data>
   <data name="settings_domain_blacklist" xml:space="preserve">
-    <value>Show &quot;Domain Blacklist&quot; Tab</value>
+    <value>Show "Domain Blacklist" Tab</value>
   </data>
   <data name="settings_address_blacklist" xml:space="preserve">
-    <value>Show &quot;Address Blacklist&quot; Tab</value>
+    <value>Show "Address Blacklist" Tab</value>
   </data>
   <data name="settings_domain_block" xml:space="preserve">
-    <value>Show &quot;Domain Block Log&quot; Tab</value>
+    <value>Show "Domain Block Log" Tab</value>
   </data>
   <data name="settings_address_block" xml:space="preserve">
-    <value>Show &quot;Address Block Log&quot; Tab</value>
+    <value>Show "Address Block Log" Tab</value>
   </data>
   <data name="settings_query_log" xml:space="preserve">
-    <value>Show &quot;Query Log&quot; Tab</value>
+    <value>Show "Query Log" Tab</value>
   </data>
   <data name="tabitem_resolvers" xml:space="preserve">
     <value>Resolvers</value>
@@ -317,7 +317,7 @@
     <value>Advanced Settings</value>
   </data>
   <data name="settings_advanced_settings" xml:space="preserve">
-    <value>Show &quot;Advanced Settings&quot; Tab</value>
+    <value>Show "Advanced Settings" Tab</value>
   </data>
   <data name="yes" xml:space="preserve">
     <value>yes</value>
@@ -514,7 +514,7 @@
     <value>Fallback Resolver</value>
   </data>
   <data name="advanced_settings_fallback_resolver_content" xml:space="preserve">
-    <value>This is a normal, non-encrypted DNS resolver, that will be only used for one-shot queries when retrieving the initial resolvers list, and only if the system DNS configuration doesn&apos;t work. People in China may need to use 114.114.114.114:53 here.</value>
+    <value>This is a normal, non-encrypted DNS resolver, that will be only used for one-shot queries when retrieving the initial resolvers list, and only if the system DNS configuration doesn't work. People in China may need to use 114.114.114.114:53 here.</value>
   </data>
   <data name="trayicon_tooltip" xml:space="preserve">
     <value>Simple DNSCrypt</value>
@@ -539,5 +539,8 @@
   </data>
   <data name="address_settings_restore" xml:space="preserve">
     <value>Restore default listen addresses</value>
+  </data>
+  <data name="button_blacklist_clear" xml:space="preserve">
+    <value>Clears all blacklist rules</value>
   </data>
 </root>

--- a/SimpleDnsCrypt/Resources/Translation.en.resx
+++ b/SimpleDnsCrypt/Resources/Translation.en.resx
@@ -543,4 +543,7 @@
   <data name="button_blacklist_clear" xml:space="preserve">
     <value>Clears all blacklist rules</value>
   </data>
+  <data name="settings_start_in_tray" xml:space="preserve">
+    <value>Start Simple DNSCrypt in tray</value>
+  </data>
 </root>

--- a/SimpleDnsCrypt/Resources/Translation.en.resx
+++ b/SimpleDnsCrypt/Resources/Translation.en.resx
@@ -541,7 +541,7 @@
     <value>Restore default listen addresses</value>
   </data>
   <data name="button_blacklist_clear" xml:space="preserve">
-    <value>Clears all blacklist rules</value>
+    <value>Clear all blacklist rules</value>
   </data>
   <data name="settings_start_in_tray" xml:space="preserve">
     <value>Start Simple DNSCrypt in tray</value>

--- a/SimpleDnsCrypt/Resources/Translation.en.resx
+++ b/SimpleDnsCrypt/Resources/Translation.en.resx
@@ -546,4 +546,7 @@
   <data name="settings_start_in_tray" xml:space="preserve">
     <value>Start Simple DNSCrypt in tray</value>
   </data>
+  <data name="settings_tray_mode" xml:space="preserve">
+    <value>Minimize to tray when closing</value>
+  </data>
 </root>

--- a/SimpleDnsCrypt/ViewModels/DomainBlacklistViewModel.cs
+++ b/SimpleDnsCrypt/ViewModels/DomainBlacklistViewModel.cs
@@ -481,6 +481,12 @@ namespace SimpleDnsCrypt.ViewModels
 			}
 		}
 
+		public void ClearDomainBlackList()
+		{
+			Execute.OnUIThread(() => { DomainBlacklistRules.Clear(); });
+			SaveBlacklistRulesToFile();
+		}
+
 		public async void AddBlacklistRule()
 		{
 			try

--- a/SimpleDnsCrypt/ViewModels/DomainBlacklistViewModel.cs
+++ b/SimpleDnsCrypt/ViewModels/DomainBlacklistViewModel.cs
@@ -485,6 +485,7 @@ namespace SimpleDnsCrypt.ViewModels
 		{
 			Execute.OnUIThread(() => { DomainBlacklistRules.Clear(); });
 			SaveBlacklistRulesToFile();
+			BuildBlacklist();
 		}
 
 		public async void AddBlacklistRule()

--- a/SimpleDnsCrypt/ViewModels/LoaderViewModel.cs
+++ b/SimpleDnsCrypt/ViewModels/LoaderViewModel.cs
@@ -185,10 +185,17 @@ namespace SimpleDnsCrypt.ViewModels
 				_mainViewModel.Initialize();
 				ProgressText = LocalizationEx.GetUiString("loader_starting", Thread.CurrentThread.CurrentCulture);
 
-				Execute.OnUIThread(() => _windowManager.ShowWindow(_systemTrayViewModel));
-				if (Properties.Settings.Default.StartInTray)
+				if(Properties.Settings.Default.TrayMode)
 				{
-					Execute.OnUIThread(() => _systemTrayViewModel.HideWindow());
+					Execute.OnUIThread(() => _windowManager.ShowWindow(_systemTrayViewModel));
+					if (Properties.Settings.Default.StartInTray)
+					{
+						Execute.OnUIThread(() => _systemTrayViewModel.HideWindow());
+					}
+					else
+					{
+						Execute.OnUIThread(() => _windowManager.ShowWindow(_mainViewModel));
+					}
 				}
 				else
 				{

--- a/SimpleDnsCrypt/ViewModels/LoaderViewModel.cs
+++ b/SimpleDnsCrypt/ViewModels/LoaderViewModel.cs
@@ -185,10 +185,10 @@ namespace SimpleDnsCrypt.ViewModels
 				_mainViewModel.Initialize();
 				ProgressText = LocalizationEx.GetUiString("loader_starting", Thread.CurrentThread.CurrentCulture);
 
-				if (Properties.Settings.Default.TrayMode)
+				Execute.OnUIThread(() => _windowManager.ShowWindow(_systemTrayViewModel));
+				if (Properties.Settings.Default.StartInTray)
 				{
-					Execute.OnUIThread(() => _windowManager.ShowWindow(_systemTrayViewModel));
-					Execute.OnUIThread(() => _systemTrayViewModel.ShowWindow());
+					Execute.OnUIThread(() => _systemTrayViewModel.HideWindow());
 				}
 				else
 				{

--- a/SimpleDnsCrypt/ViewModels/SettingsViewModel.cs
+++ b/SimpleDnsCrypt/ViewModels/SettingsViewModel.cs
@@ -12,6 +12,7 @@ namespace SimpleDnsCrypt.ViewModels
 		private string _windowTitle;
 		private bool _isAdvancedSettingsTabVisible;
 		private bool _isStartInTrayEnabled;
+		private bool _isTrayModeEnabled;
 		private bool _isQueryLogTabVisible;
 		private bool _isDomainBlacklistTabVisible;
 		private bool _isDomainBlockLogTabVisible;
@@ -34,6 +35,7 @@ namespace SimpleDnsCrypt.ViewModels
 			_events.Subscribe(this);
 			_isAdvancedSettingsTabVisible = Properties.Settings.Default.IsAdvancedSettingsTabVisible;
 			_isStartInTrayEnabled = Properties.Settings.Default.StartInTray;
+			_isTrayModeEnabled = Properties.Settings.Default.TrayMode;
 			_isQueryLogTabVisible = Properties.Settings.Default.IsQueryLogTabVisible;
 			_isDomainBlacklistTabVisible = Properties.Settings.Default.IsDomainBlacklistTabVisible;
 			_isDomainBlockLogTabVisible = Properties.Settings.Default.IsDomainBlockLogTabVisible;
@@ -86,7 +88,18 @@ namespace SimpleDnsCrypt.ViewModels
 			{
 				_isStartInTrayEnabled = value;
 				Properties.Settings.Default.StartInTray = _isStartInTrayEnabled;
-				NotifyOfPropertyChange(() => _isStartInTrayEnabled);
+				NotifyOfPropertyChange(() => IsStartInTrayEnabled);
+			}
+		}
+		public bool IsTrayModeEnabled
+		{
+			get => _isTrayModeEnabled;
+			set
+			{
+				_isTrayModeEnabled = value;
+				Properties.Settings.Default.TrayMode = _isTrayModeEnabled;
+				NotifyOfPropertyChange(() => IsTrayModeEnabled);
+				if (!IsTrayModeEnabled && IsStartInTrayEnabled) IsStartInTrayEnabled = false;
 			}
 		}
 

--- a/SimpleDnsCrypt/ViewModels/SettingsViewModel.cs
+++ b/SimpleDnsCrypt/ViewModels/SettingsViewModel.cs
@@ -11,6 +11,7 @@ namespace SimpleDnsCrypt.ViewModels
 		private readonly IEventAggregator _events;
 		private string _windowTitle;
 		private bool _isAdvancedSettingsTabVisible;
+		private bool _isStartInTrayEnabled;
 		private bool _isQueryLogTabVisible;
 		private bool _isDomainBlacklistTabVisible;
 		private bool _isDomainBlockLogTabVisible;
@@ -32,6 +33,7 @@ namespace SimpleDnsCrypt.ViewModels
 			_events = events;
 			_events.Subscribe(this);
 			_isAdvancedSettingsTabVisible = Properties.Settings.Default.IsAdvancedSettingsTabVisible;
+			_isStartInTrayEnabled = Properties.Settings.Default.StartInTray;
 			_isQueryLogTabVisible = Properties.Settings.Default.IsQueryLogTabVisible;
 			_isDomainBlacklistTabVisible = Properties.Settings.Default.IsDomainBlacklistTabVisible;
 			_isDomainBlockLogTabVisible = Properties.Settings.Default.IsDomainBlockLogTabVisible;
@@ -74,6 +76,17 @@ namespace SimpleDnsCrypt.ViewModels
 				_isAdvancedSettingsTabVisible = value;
 				Properties.Settings.Default.IsAdvancedSettingsTabVisible = _isAdvancedSettingsTabVisible;
 				NotifyOfPropertyChange(() => IsAdvancedSettingsTabVisible);
+			}
+		}
+
+		public bool IsStartInTrayEnabled
+		{
+			get => _isStartInTrayEnabled;
+			set
+			{
+				_isStartInTrayEnabled = value;
+				Properties.Settings.Default.StartInTray = _isStartInTrayEnabled;
+				NotifyOfPropertyChange(() => _isStartInTrayEnabled);
 			}
 		}
 

--- a/SimpleDnsCrypt/Views/MainView.xaml
+++ b/SimpleDnsCrypt/Views/MainView.xaml
@@ -1760,8 +1760,31 @@
                                                             Content="{lex:Loc Key=button_blacklist_build}"
                                                             FontWeight="DemiBold" />
                                                     </Button.ToolTip>
-                                                </Button>
-                                            </StackPanel>
+                                            </Button>
+                                            <Button x:Name="ClearDomainBlackList" cal:Message.Attach="ClearDomainBlackList"
+                                                        Background="White"
+                                                        Width="30"
+                                                        Height="30"
+                                                        Cursor="Hand"
+                                                        HorizontalContentAlignment="Center"
+                                                        VerticalContentAlignment="Center"
+                                                        BorderBrush="{DynamicResource AccentColorBrush}"
+                                                        FocusVisualStyle="{DynamicResource MahApps.Metro.Styles.MetroCircleFocusVisual}"
+                                                        Style="{DynamicResource MahApps.Metro.Styles.MetroCircleButtonStyle}"
+                                                        Margin="0,7,0,0">
+                                                <iconPacks:PackIconMaterial
+                                                        Kind="NotificationClearAll"
+                                                        Width="15"
+                                                        Height="15"
+                                                        HorizontalContentAlignment="Center"
+                                                        VerticalContentAlignment="Center"
+                                                        Foreground="{DynamicResource AccentColorBrush}" />
+                                                <Button.ToolTip>
+                                                    <Label Content="{lex:Loc Key=button_blacklist_clear}"
+                                                               FontWeight="DemiBold" />
+                                                </Button.ToolTip>
+                                            </Button>
+                                        </StackPanel>
                                         </Grid>
 
                                         <Grid Grid.Column="0" Grid.Row="7" Grid.ColumnSpan="2" Margin="0,5,0,0">

--- a/SimpleDnsCrypt/Views/SettingsView.xaml
+++ b/SimpleDnsCrypt/Views/SettingsView.xaml
@@ -55,6 +55,11 @@
                         Content="{lex:Loc Key=settings_advanced_settings}"
                         Cursor="Hand" Foreground="#FF575757" />
                     <CheckBox
+                        IsChecked="{Binding IsStartInTrayEnabled}"
+                        Margin="5"
+                        Content="{lex:Loc Key=settings_start_in_tray}"
+                        Cursor="Hand" Foreground="#FF575757" />
+                    <CheckBox
                         IsChecked="{Binding IsQueryLogTabVisible}"
                         Margin="5"
                         Content="{lex:Loc Key=settings_query_log}"

--- a/SimpleDnsCrypt/Views/SettingsView.xaml
+++ b/SimpleDnsCrypt/Views/SettingsView.xaml
@@ -49,13 +49,23 @@
                     </TextBlock>
                 </StackPanel>
                 <StackPanel Orientation="Vertical">
+                    <StackPanel.Resources>
+                        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+                    </StackPanel.Resources>
                     <CheckBox
                         IsChecked="{Binding IsAdvancedSettingsTabVisible}"
                         Margin="5"
                         Content="{lex:Loc Key=settings_advanced_settings}"
                         Cursor="Hand" Foreground="#FF575757" />
                     <CheckBox
+                        IsChecked="{Binding IsTrayModeEnabled}"
+                        Margin="5"
+                        Content="{lex:Loc Key=settings_tray_mode}"
+                        Cursor="Hand" Foreground="#FF575757" />
+                    <CheckBox
                         IsChecked="{Binding IsStartInTrayEnabled}"
+                        IsEnabled="{Binding IsTrayModeEnabled}"
+                        Visibility="{Binding IsTrayModeEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
                         Margin="5"
                         Content="{lex:Loc Key=settings_start_in_tray}"
                         Cursor="Hand" Foreground="#FF575757" />


### PR DESCRIPTION
These commits contain multiple changes to enhance this project.

1. On the blacklist tab a new button was added which clears all rules and compiles an empty list as managing large lists was simply not possible with the single line removal button.

2. The option to disable tray mode was added in the settings menu. Some users might not like to have SimpleDnsCrypt running in the background and going to the tray to close it could potentially be annoying.

3. Furthermore, a new option was added to launch SimpleDnsCrypt in the tray. This option is also found in the settings menu and will automatically be disabled if a user completely disables tray mode. I added this feature because I personally like to have SimpleDnsCrypt autostart with Windows which caused the window to pop up with the current official release and got rather annoying.

The order of the settings in the settings menu may not be optimal but it should be easy to adjust.