### PR TITLE
Implement color coding for DNS return codes

### DIFF
--- a/SimpleDnsCrypt/Converters/QueryLogReturnCodeToColorConverter.cs
+++ b/SimpleDnsCrypt/Converters/QueryLogReturnCodeToColorConverter.cs
@@ -1,0 +1,45 @@
+﻿using SimpleDnsCrypt.Models;
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace SimpleDnsCrypt.Converters
+{
+	public class QueryLogReturnCodeToColorConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var logLineReturnCode = (QueryLogReturnCode) value;
+			switch (logLineReturnCode)
+			{
+				case QueryLogReturnCode.PASS:
+					return "#FF8ab329";
+				case QueryLogReturnCode.FORWARD:
+					return "#FF8ab329";
+				case QueryLogReturnCode.DROP:
+					return "#FFB32929";
+				case QueryLogReturnCode.REJECT:
+					return "#FFB32929";
+				case QueryLogReturnCode.SYNTH:
+					return "#FF8ab329";
+				case QueryLogReturnCode.PARSE_ERROR:
+					return "#FFB32929";
+				case QueryLogReturnCode.NXDOMAIN:
+					return "#FFB36729";
+				case QueryLogReturnCode.RESPONSE_ERROR:
+					return "#FFB32929";
+				case QueryLogReturnCode.SERVER_ERROR:
+					return "#FFB32929";
+				case QueryLogReturnCode.CLOAK:
+					return "#FF2a3b68";
+				default:
+					return "#FFB32929";
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/SimpleDnsCrypt/SimpleDnsCrypt.csproj
+++ b/SimpleDnsCrypt/SimpleDnsCrypt.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Converters\LocalDateConverter.cs" />
     <Compile Include="Converters\MessageBoxTypeToColor.cs" />
     <Compile Include="Converters\ProtocolToVisibilityConverter.cs" />
+    <Compile Include="Converters\QueryLogReturnCodeToColorConverter.cs" />
     <Compile Include="Converters\QueryLogTypeToColorConverter.cs" />
     <Compile Include="Converters\ReverseBoolToEnabledConverter.cs" />
     <Compile Include="Converters\RouteStateToColorConverter.cs" />

--- a/SimpleDnsCrypt/Views/MainView.xaml
+++ b/SimpleDnsCrypt/Views/MainView.xaml
@@ -25,6 +25,7 @@
             <converters:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
             <converters:ReverseBoolToEnabledConverter x:Key="ReverseBoolToEnabledConverter" />
             <converters:QueryLogTypeToColorConverter x:Key="QueryLogTypeToColorConverter" />
+            <converters:QueryLogReturnCodeToColorConverter x:Key="QueryLogReturnCodeToColorConverter" />
             <converters:LocalDateConverter x:Key="LocalDateConverter" />
             <converters:IntegerBoolToVisibilityConverter x:Key="IntegerBoolToVisibilityConverter" />
             <converters:ServerListBackgroundConverter x:Key="ServerListBackgroundConverter" />
@@ -1049,7 +1050,7 @@
                                                             <TextBlock Grid.Column="1" Text="{Binding Type}"
                                                                        Foreground="{Binding Type, Converter={StaticResource QueryLogTypeToColorConverter}}" />
                                                             <TextBlock Grid.Column="2" Text="{Binding ReturnCode}"
-                                                                       Foreground="#FF575757" />
+                                                                       Foreground="{Binding ReturnCode, Converter={StaticResource QueryLogReturnCodeToColorConverter}}" />
                                                             <TextBlock Grid.Column="3" Text="{Binding Address}"
                                                                        Foreground="#FF575757" />
                                                             <TextBlock Grid.Column="4" Text="{Binding Remote}"


### PR DESCRIPTION
This pull request implements color coding for DNS return codes to make it easier to spot errors or blocked requests in the query log. The color codes are only grouped really roughly so feel free to edit them.